### PR TITLE
open ai compatible endpoints (like llama-server) supported

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 Topics: eclipse-plugin, ollama, local-llm, ai-coding-assistant, java, eclipse-ide
 
-**A privacy-first AI coding assistant for Eclipse IDE, powered by local Ollama models like CodeLlama and DeepSeek Coder. Features: AI chat, code explanation, bug fixes, test generation, Javadoc. 100% local, no cloud.**
+**A privacy-first AI coding assistant for Eclipse IDE, powered by local Ollama or OpenAI models like CodeLlama and DeepSeek Coder. Features: AI chat, code explanation, bug fixes, test generation, Javadoc. 100% local, no cloud.**
 
 ---
 
@@ -26,7 +26,8 @@ Topics: eclipse-plugin, ollama, local-llm, ai-coding-assistant, java, eclipse-id
 
 1. **Eclipse IDE** 2023-12 or newer
 2. **Java 21** or compatible JDK
-3. **Ollama** installed and running ([Download](https://ollama.com))
+3. **Ollama** installed and running ([Download](https://ollama.com)) or 
+   **Open AI** compatible endpoint (like llama-server) installed and running
 
 ### Install a Code Model
 

--- a/src/com/eclipsellama/plugin/completion/EclipseLlamaProposalComputer.java
+++ b/src/com/eclipsellama/plugin/completion/EclipseLlamaProposalComputer.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
@@ -55,7 +56,7 @@ public class EclipseLlamaProposalComputer implements IJavaCompletionProposalComp
             String model = EclipseLlamaPreferences.getModel();
 
             // Async completion with timeout
-            CompletableFuture<String> future = OllamaClient.generateAsync(prompt, model);
+            CompletableFuture<String> future = ClientProvider.getClient().generateAsync(prompt, model);
 
             String suggestion = future.get(COMPLETION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 

--- a/src/com/eclipsellama/plugin/core/ClientProvider.java
+++ b/src/com/eclipsellama/plugin/core/ClientProvider.java
@@ -1,0 +1,36 @@
+package com.eclipsellama.plugin.core;
+
+import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
+import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences.BackendType;
+
+/**
+ * Singleton helper to provide the correct LLMClient instance.
+ */
+public class ClientProvider {
+
+    private static LLMClient ollamaClient;
+    private static LLMClient openAIClient;
+
+    private ClientProvider() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Initialize or refresh the client based on preferences.
+     */
+    public static void initClient() {
+        openAIClient = new OpenAIClient();
+        ollamaClient = new OllamaClient();
+    }
+
+    /**
+     * Get the current client instance.
+     */
+    public static LLMClient getClient() {
+        if (ollamaClient == null || openAIClient == null) {
+            initClient();
+        }
+        BackendType backendType = EclipseLlamaPreferences.getBackendType();
+        return (backendType==BackendType.OPENAI)?openAIClient:ollamaClient; 
+    }
+}

--- a/src/com/eclipsellama/plugin/core/LLMClient.java
+++ b/src/com/eclipsellama/plugin/core/LLMClient.java
@@ -1,0 +1,18 @@
+package com.eclipsellama.plugin.core;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+
+public interface LLMClient {
+    boolean isServerReachable();
+    String[] getAvailableModels();
+    String chat(String prompt, String model);
+    String chat(String prompt, String model, float temperature, int maxTokens);
+    void streamChat(List<ChatMessage> messages, String model,
+                    Consumer<String> onChunk, Consumer<String> onComplete, Consumer<String> onError);
+    void streamChat(List<ChatMessage> messages, String model, float temperature, int maxTokens,
+                    Consumer<String> onChunk, Consumer<String> onComplete, Consumer<String> onError);
+    String generate(String prompt, String model);
+    CompletableFuture<String> generateAsync(String prompt, String model);
+}

--- a/src/com/eclipsellama/plugin/core/OllamaJsonHelper.java
+++ b/src/com/eclipsellama/plugin/core/OllamaJsonHelper.java
@@ -5,17 +5,16 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Centralized JSON utilities for EclipseLlama.
- * Uses org.json library for reliable parsing.
+ * JSON-Hilfsklasse für Ollama API.
  */
-public final class JsonHelper {
+public final class OllamaJsonHelper {
 
-    private JsonHelper() {
+    private OllamaJsonHelper() {
         // Utility class
     }
 
     /**
-     * Escape a string for safe JSON inclusion.
+     * Escapet einen String für die sichere JSON-Einbindung.
      */
     public static String escape(String input) {
         if (input == null) {
@@ -30,7 +29,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Parse the "response" field from Ollama /api/generate response.
+     * Parse die "response" Feld aus Ollama /api/generate Antwort.
      */
     public static String parseGenerateResponse(String json) {
         try {
@@ -42,7 +41,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Parse the "content" field from Ollama /api/chat streaming response.
+     * Parse das "content" Feld aus Ollama /api/chat Streaming Antwort.
      */
     public static String parseChatChunk(String json) {
         try {
@@ -58,7 +57,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Check if the streaming response indicates completion.
+     * Prüft, ob das Streaming bei Ollama abgeschlossen ist.
      */
     public static boolean isDone(String json) {
         try {
@@ -70,7 +69,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Parse model names from /api/tags response.
+     * Parse Modellnamen aus Ollama /api/tags Antwort.
      */
     public static String[] parseModelList(String json) {
         try {
@@ -91,7 +90,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Build a chat message JSON object.
+     * Baut ein Chat-Message JSON Objekt.
      */
     public static JSONObject buildChatMessage(String role, String content) {
         JSONObject msg = new JSONObject();
@@ -101,7 +100,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Build the full chat request payload.
+     * Baut ein Chat-Request Payload für Ollama.
      */
     public static String buildChatRequest(String model, JSONArray messages, boolean stream) {
         JSONObject request = new JSONObject();
@@ -112,7 +111,7 @@ public final class JsonHelper {
     }
 
     /**
-     * Build a generate request payload.
+     * Baut ein Generate-Request Payload für Ollama.
      */
     public static String buildGenerateRequest(String model, String prompt, boolean stream) {
         JSONObject request = new JSONObject();

--- a/src/com/eclipsellama/plugin/core/OpenAIClient.java
+++ b/src/com/eclipsellama/plugin/core/OpenAIClient.java
@@ -17,12 +17,12 @@ import org.json.JSONArray;
 
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
-public class OllamaClient implements LLMClient {
+public class OpenAIClient implements LLMClient {
 
     private static final int CONNECT_TIMEOUT = 10000;
     private static final int READ_TIMEOUT = 120000;
 
-    public OllamaClient() {
+    public OpenAIClient() {
         // Constructor
     }
 
@@ -30,12 +30,17 @@ public class OllamaClient implements LLMClient {
         return EclipseLlamaPreferences.getEndpoint();
     }
 
+    private String getApiKey() {
+        return EclipseLlamaPreferences.getApiKey();
+    }
+
     @Override
     public boolean isServerReachable() {
         try {
-            URL url = new URL(getEndpoint() + "/api/tags");
+            URL url = new URL(getEndpoint() + "/models");
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "Bearer " + getApiKey());
             conn.setConnectTimeout(3000);
             conn.setReadTimeout(3000);
             try {
@@ -52,9 +57,10 @@ public class OllamaClient implements LLMClient {
     @Override
     public String[] getAvailableModels() {
         try {
-            URL url = new URL(getEndpoint() + "/api/tags");
+            URL url = new URL(getEndpoint() + "/models");
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "Bearer " + getApiKey());
             conn.setConnectTimeout(CONNECT_TIMEOUT);
             conn.setReadTimeout(READ_TIMEOUT);
 
@@ -64,7 +70,7 @@ public class OllamaClient implements LLMClient {
                     return new String[0];
                 }
                 String response = readResponse(conn.getInputStream());
-                return OllamaJsonHelper.parseModelList(response);
+                return OpenAIJsonHelper.parseOpenAIModelList(response);
             } finally {
                 conn.disconnect();
             }
@@ -81,9 +87,11 @@ public class OllamaClient implements LLMClient {
     @Override
     public String chat(String prompt, String model, float temperature, int maxTokens) {
         try {
-            String payload = OllamaJsonHelper.buildGenerateRequest(model, prompt, false);
-            String response = sendPost(getEndpoint() + "/api/generate", payload);
-            return OllamaJsonHelper.parseGenerateResponse(response);
+            JSONArray messages = new JSONArray();
+            messages.put(OpenAIJsonHelper.buildChatMessage("user", prompt));
+            String payload = OpenAIJsonHelper.buildOpenAIChatRequest(model, messages, false, temperature, maxTokens);
+            String response = sendPost(getEndpoint() + "/chat/completions", payload);
+            return OpenAIJsonHelper.parseOpenAIChatResponse(response);
         } catch (Exception e) {
             return "Error: " + e.getMessage();
         }
@@ -105,14 +113,15 @@ public class OllamaClient implements LLMClient {
             try {
                 JSONArray jsonMessages = new JSONArray();
                 for (ChatMessage msg : messages) {
-                    jsonMessages.put(OllamaJsonHelper.buildChatMessage(msg.getRole(), msg.getContent()));
+                    jsonMessages.put(OpenAIJsonHelper.buildChatMessage(msg.getRole(), msg.getContent()));
                 }
 
-                String payload = OllamaJsonHelper.buildChatRequest(model, jsonMessages, true);
+                String payload = OpenAIJsonHelper.buildOpenAIChatRequest(model, jsonMessages, true, temperature, maxTokens);
 
-                URL url = new URL(getEndpoint() + "/api/chat");
+                URL url = new URL(getEndpoint() + "/chat/completions");
                 conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("POST");
+                conn.setRequestProperty("Authorization", "Bearer " + getApiKey());
                 conn.setRequestProperty("Content-Type", "application/json");
                 conn.setRequestProperty("Accept", "application/json");
                 conn.setConnectTimeout(CONNECT_TIMEOUT);
@@ -132,11 +141,13 @@ public class OllamaClient implements LLMClient {
                         new InputStreamReader(stream, StandardCharsets.UTF_8))) {
                     String line;
                     while ((line = reader.readLine()) != null) {
-                        String chunk = OllamaJsonHelper.parseChatChunk(line);
-                        if (!chunk.isEmpty()) {
+                        String chunk = OpenAIJsonHelper.parseOpenAIChatChunk(line);
+                        if (chunk != null) {
                             fullResponse.append(chunk);
                             final String c = chunk;
                             Display.getDefault().asyncExec(() -> onChunk.accept(c));
+                        } else if (OpenAIJsonHelper.isOpenAIDone(line)) {
+                            break;
                         }
                     }
                 }
@@ -155,16 +166,11 @@ public class OllamaClient implements LLMClient {
         });
     }
 
-   
+  
     @Override
     public String generate(String prompt, String model) {
-        try {
-            String payload = OllamaJsonHelper.buildGenerateRequest(model, prompt, false);
-            String response = sendPost(getEndpoint() + "/api/generate", payload);
-            return OllamaJsonHelper.parseGenerateResponse(response);
-        } catch (Exception e) {
-            return "Error: " + e.getMessage();
-        }
+        // Map generate to chat with single user message for OpenAI
+        return chat(prompt, model, 0.7f, 2048);
     }
 
     @Override
@@ -178,6 +184,7 @@ public class OllamaClient implements LLMClient {
         URL url = new URL(endpoint);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("POST");
+        conn.setRequestProperty("Authorization", "Bearer " + getApiKey());
         conn.setRequestProperty("Content-Type", "application/json");
         conn.setRequestProperty("Accept", "application/json");
         conn.setConnectTimeout(CONNECT_TIMEOUT);

--- a/src/com/eclipsellama/plugin/core/OpenAIJsonHelper.java
+++ b/src/com/eclipsellama/plugin/core/OpenAIJsonHelper.java
@@ -1,0 +1,179 @@
+package com.eclipsellama.plugin.core;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * JSON-Hilfsklasse für OpenAI API.
+ */
+public final class OpenAIJsonHelper {
+
+    private OpenAIJsonHelper() {
+        // Utility class
+    }
+
+    /**
+     * Escapet einen String für die sichere JSON-Einbindung.
+     */
+    public static String escape(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    /**
+     * Parse das "content" Feld aus OpenAI /v1/chat/completions Streaming Antwort.
+     * Verarbeitet SSE-Format (data: ...) und [DONE] Marker.
+     */
+    public static String parseOpenAIChatChunk(String json) {
+        try {
+            // Entferne SSE Prefix falls vorhanden
+            String data = json;
+            if (data.startsWith("data: ")) {
+                data = data.substring(6);
+            }
+
+            // Handle EOF Marker
+            if ("[DONE]".equals(data.trim())) {
+                return null; // Signal für Ende
+            }
+
+            JSONObject obj = new JSONObject(data);
+            JSONArray choices = obj.optJSONArray("choices");
+            if (choices != null && choices.length() > 0) {
+                JSONObject choice = choices.getJSONObject(0);
+                JSONObject delta = choice.optJSONObject("delta");
+                if (delta != null) {
+                    return delta.optString("content", "");
+                }
+            }
+            return "";
+        } catch (JSONException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Prüft, ob das Streaming bei OpenAI abgeschlossen ist.
+     */
+    public static boolean isOpenAIDone(String json) {
+        return "[DONE]".equals(json.trim());
+    }
+
+    /**
+     * Parse die vollständige Antwort aus OpenAI /v1/chat/completions.
+     */
+    public static String parseOpenAIChatResponse(String json) {
+        try {
+            JSONObject obj = new JSONObject(json);
+            JSONArray choices = obj.optJSONArray("choices");
+            if (choices != null && choices.length() > 0) {
+                JSONObject choice = choices.getJSONObject(0);
+                JSONObject message = choice.optJSONObject("message");
+                if (message != null) {
+                    return message.optString("content", "");
+                }
+            }
+            return "";
+        } catch (JSONException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Parse Modellnamen aus OpenAI /v1/models Antwort.
+     */
+    public static String[] parseOpenAIModelList(String json) {
+        try {
+            JSONObject obj = new JSONObject(json);
+            JSONArray models = obj.optJSONArray("data");
+            if (models == null) {
+                return new String[0];
+            }
+            String[] result = new String[models.length()];
+            for (int i = 0; i < models.length(); i++) {
+                JSONObject model = models.getJSONObject(i);
+                result[i] = model.optString("id", "unknown");
+            }
+            return result;
+        } catch (JSONException e) {
+            return new String[0];
+        }
+    }
+
+    /**
+     * Baut ein Chat-Message JSON Objekt.
+     */
+    public static JSONObject buildChatMessage(String role, String content) {
+        JSONObject msg = new JSONObject();
+        msg.put("role", role);
+        msg.put("content", content);
+        return msg;
+    }
+
+    /**
+     * Baut ein Chat-Request Payload für OpenAI.
+     */
+    public static String buildOpenAIChatRequest(String model, JSONArray messages, boolean stream) {
+        JSONObject request = new JSONObject();
+        request.put("model", model);
+        request.put("messages", messages);
+        request.put("stream", stream);
+        return request.toString();
+    }
+
+    /**
+     * Baut ein Chat-Request Payload für OpenAI mit Temperatur.
+     */
+    public static String buildOpenAIChatRequest(String model, JSONArray messages, boolean stream, float temperature) {
+        JSONObject request = new JSONObject();
+        request.put("model", model);
+        request.put("messages", messages);
+        request.put("stream", stream);
+        request.put("temperature", temperature);
+        return request.toString();
+    }
+
+    /**
+     * Baut ein Chat-Request Payload für OpenAI mit Temperatur und Max Tokens.
+     */
+    public static String buildOpenAIChatRequest(String model, JSONArray messages, boolean stream, float temperature, int maxTokens) {
+        JSONObject request = new JSONObject();
+        request.put("model", model);
+        request.put("messages", messages);
+        request.put("stream", stream);
+        request.put("temperature", temperature);
+        request.put("max_tokens", maxTokens);
+        return request.toString();
+    }
+
+    /**
+     * Baut ein Completion-Request Payload für OpenAI.
+     */
+    public static String buildOpenAICompletionRequest(String model, String prompt, boolean stream) {
+        JSONObject request = new JSONObject();
+        request.put("model", model);
+        request.put("prompt", prompt);
+        request.put("stream", stream);
+        return request.toString();
+    }
+
+    /**
+     * Baut ein Completion-Request Payload für OpenAI mit Temperatur.
+     */
+    public static String buildOpenAICompletionRequest(String model, String prompt, boolean stream, float temperature) {
+        JSONObject request = new JSONObject();
+        request.put("model", model);
+        request.put("prompt", prompt);
+        request.put("stream", stream);
+        request.put("temperature", temperature);
+        return request.toString();
+    }
+}

--- a/src/com/eclipsellama/plugin/git/CommitMessageGenerator.java
+++ b/src/com/eclipsellama/plugin/git/CommitMessageGenerator.java
@@ -1,5 +1,6 @@
 package com.eclipsellama.plugin.git;
 
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
@@ -35,7 +36,7 @@ public class CommitMessageGenerator {
 
         try {
             lastModel = EclipseLlamaPreferences.getModel();
-            String result = OllamaClient.generate(prompt, lastModel);
+            String result = ClientProvider.getClient().generate(prompt, lastModel);
             lastRawResponse = result;
 
             // Clean up the response

--- a/src/com/eclipsellama/plugin/preferences/EclipseLlamaPreferencePage.java
+++ b/src/com/eclipsellama/plugin/preferences/EclipseLlamaPreferencePage.java
@@ -15,14 +15,18 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 
 /**
  * Preferences page for EclipseLlama settings.
  */
 public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
+	public EclipseLlamaPreferencePage() {
+	}
 
     private Text endpointText;
+    private Text apiKeyText;
     private Combo modelCombo;
     private Text commitPromptText;
     private Label statusLabel;
@@ -47,8 +51,8 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
 
     private void createConnectionGroup(Composite parent) {
         Group group = new Group(parent, SWT.NONE);
-        group.setText("Ollama Connection");
-        group.setLayout(new GridLayout(3, false));
+        group.setText("LLM Connection");
+        group.setLayout(new GridLayout(2, false));
         group.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
         Label endpointLabel = new Label(group, SWT.NONE);
@@ -56,6 +60,13 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
 
         endpointText = new Text(group, SWT.BORDER);
         endpointText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+        
+        Label apiKeyLabel = new Label(group, SWT.NONE);
+        apiKeyLabel.setText("Api key:");
+
+        apiKeyText = new Text(group, SWT.BORDER);
+        apiKeyText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
 
         Button testBtn = new Button(group, SWT.PUSH);
         testBtn.setText("Test");
@@ -64,6 +75,8 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
         new Label(group, SWT.NONE); // Spacer
         statusLabel = new Label(group, SWT.NONE);
         statusLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+        new Label(group, SWT.NONE);
+        new Label(group, SWT.NONE);
     }
 
     private void createModelGroup(Composite parent) {
@@ -103,7 +116,8 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
     }
 
     private void loadPreferences() {
-        endpointText.setText(EclipseLlamaPreferences.getOllamaEndpoint());
+        endpointText.setText(EclipseLlamaPreferences.getEndpoint());
+        apiKeyText.setText(EclipseLlamaPreferences.getApiKey());
         commitPromptText.setText(EclipseLlamaPreferences.getCommitPrompt());
 
         // Load models
@@ -124,13 +138,13 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
         statusLabel.setText("Testing...");
 
         new Thread(() -> {
-            boolean ok = OllamaClient.isServerReachable();
+            boolean ok = ClientProvider.getClient().isServerReachable();
             Display.getDefault().asyncExec(() -> {
                 if (ok) {
                     statusLabel.setText("✅ Connected successfully");
                     refreshModels();
                 } else {
-                    statusLabel.setText("❌ Cannot connect to Ollama");
+                    statusLabel.setText("❌ Cannot connect to endpoint");
                 }
             });
         }).start();
@@ -138,7 +152,7 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
 
     private void refreshModels() {
         new Thread(() -> {
-            String[] models = OllamaClient.getAvailableModels();
+            String[] models = ClientProvider.getClient().getAvailableModels();
             Display.getDefault().asyncExec(() -> {
                 if (models.length > 0) {
                     String current = modelCombo.getText();
@@ -170,7 +184,8 @@ public class EclipseLlamaPreferencePage extends PreferencePage implements IWorkb
     }
 
     private void savePreferences() {
-        EclipseLlamaPreferences.setOllamaEndpoint(endpointText.getText());
+        EclipseLlamaPreferences.setEndpoint(endpointText.getText());
+        EclipseLlamaPreferences.setApiKey(apiKeyText.getText());
         EclipseLlamaPreferences.setModel(modelCombo.getText());
         EclipseLlamaPreferences.setCommitPrompt(commitPromptText.getText());
         EclipseLlamaPreferences.save();

--- a/src/com/eclipsellama/plugin/preferences/EclipseLlamaPreferences.java
+++ b/src/com/eclipsellama/plugin/preferences/EclipseLlamaPreferences.java
@@ -22,6 +22,7 @@ public final class EclipseLlamaPreferences {
     private static final String KEY_MODEL = "ollama.model";
     private static final String KEY_SETUP_COMPLETE = "setup.complete";
     private static final String KEY_COMMIT_PROMPT = "commit.prompt";
+    private static final String KEY_API_KEY = "api.key";
 
     // Defaults
     private static final String DEFAULT_ENDPOINT = "http://localhost:11434";
@@ -31,6 +32,11 @@ public final class EclipseLlamaPreferences {
 
     private static Properties properties;
     private static boolean loaded = false;
+    
+    public enum BackendType {
+    	OLLAMA,
+    	OPENAI
+    }
 
     private EclipseLlamaPreferences() {
         // Utility class
@@ -65,6 +71,7 @@ public final class EclipseLlamaPreferences {
         properties.setProperty(KEY_MODEL, DEFAULT_MODEL);
         properties.setProperty(KEY_SETUP_COMPLETE, "false");
         properties.setProperty(KEY_COMMIT_PROMPT, DEFAULT_COMMIT_PROMPT);
+        properties.setProperty(KEY_API_KEY, "");
 
         // Load from file if exists
         Path configFile = getConfigFile();
@@ -101,17 +108,17 @@ public final class EclipseLlamaPreferences {
     }
 
     /**
-     * Get Ollama endpoint URL.
+     * Get endpoint URL.
      */
-    public static String getOllamaEndpoint() {
+    public static String getEndpoint() {
         load();
         return properties.getProperty(KEY_ENDPOINT, DEFAULT_ENDPOINT);
     }
 
     /**
-     * Set Ollama endpoint URL.
+     * Set endpoint URL.
      */
-    public static void setOllamaEndpoint(String endpoint) {
+    public static void setEndpoint(String endpoint) {
         load();
         properties.setProperty(KEY_ENDPOINT,
                 (endpoint == null || endpoint.isBlank()) ? DEFAULT_ENDPOINT : endpoint.trim());
@@ -132,6 +139,23 @@ public final class EclipseLlamaPreferences {
         load();
         properties.setProperty(KEY_MODEL,
                 (model == null || model.isBlank()) ? DEFAULT_MODEL : model.trim());
+    }
+    
+    /**
+     * Get api key.
+     */
+    public static String getApiKey() {
+        load();
+        return properties.getProperty(KEY_API_KEY, "");
+    }
+
+    /**
+     * Set api key.
+     */
+    public static void setApiKey(String key) {
+        load();
+        properties.setProperty(KEY_API_KEY,
+                (key == null || key.isBlank()) ? "" : key.trim());
     }
 
     /**
@@ -187,5 +211,12 @@ public final class EclipseLlamaPreferences {
      */
     public static boolean configExists() {
         return Files.exists(getConfigFile());
+    }
+    
+    /**
+     * Get backend type
+     */
+    public static BackendType getBackendType() {
+    	return (getEndpoint()!=null && getEndpoint().contains("v1"))?BackendType.OPENAI:BackendType.OLLAMA;
     }
 }

--- a/src/com/eclipsellama/plugin/setup/SetupLauncher.java
+++ b/src/com/eclipsellama/plugin/setup/SetupLauncher.java
@@ -3,6 +3,7 @@ package com.eclipsellama.plugin.setup;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IStartup;
 
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
@@ -23,9 +24,9 @@ public class SetupLauncher implements IStartup {
         // Skip if already configured
         if (EclipseLlamaPreferences.isSetupComplete()) {
             // Just verify connection silently
-            if (!OllamaClient.isServerReachable()) {
-                System.out.println("EclipseLlama: Warning - Ollama server not reachable at "
-                        + EclipseLlamaPreferences.getOllamaEndpoint());
+            if (!ClientProvider.getClient().isServerReachable()) {
+                System.out.println("EclipseLlama: Warning - endpoint not reachable at "
+                        + EclipseLlamaPreferences.getEndpoint());
             }
             return;
         }

--- a/src/com/eclipsellama/plugin/setup/SetupWizardDialog.java
+++ b/src/com/eclipsellama/plugin/setup/SetupWizardDialog.java
@@ -14,6 +14,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
@@ -23,6 +24,7 @@ import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 public class SetupWizardDialog extends TitleAreaDialog {
 
     private Text endpointText;
+    private Text apiKeyText;
     private Combo modelCombo;
     private Label statusLabel;
 
@@ -54,11 +56,19 @@ public class SetupWizardDialog extends TitleAreaDialog {
 
         // Endpoint
         Label endpointLabel = new Label(container, SWT.NONE);
-        endpointLabel.setText("Ollama URL:");
+        endpointLabel.setText("Endpoint URL:");
 
         endpointText = new Text(container, SWT.BORDER);
         endpointText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-        endpointText.setText(EclipseLlamaPreferences.getOllamaEndpoint());
+        endpointText.setText(EclipseLlamaPreferences.getEndpoint());
+
+        // Api key
+        Label apiKeyLabel = new Label(container, SWT.NONE);
+        apiKeyLabel.setText("Api key:");
+
+        apiKeyText = new Text(container, SWT.BORDER);
+        apiKeyText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+        apiKeyText.setText(EclipseLlamaPreferences.getApiKey());
 
         // Test connection button
         new Label(container, SWT.NONE); // Spacer
@@ -92,11 +102,15 @@ public class SetupWizardDialog extends TitleAreaDialog {
         infoData.widthHint = 400;
         infoLabel.setLayoutData(infoData);
         infoLabel.setText(
-                "\n📋 Quick Start:\n" +
+                "\n📋 Quick Start(Ollama):\n" +
                         "1. Install Ollama from ollama.com\n" +
                         "2. Run: ollama pull codellama\n" +
                         "3. Make sure Ollama is running\n" +
                         "4. Click 'Test Connection' above\n\n" +
+                 "\n📋 Quick Start(Open AI compabitble):\n" +
+                        "1. Make sure your Open AI compatible endpoint (f.e. llama-server) is running \n" +
+                        "2. Make sure test endpoint Url ends with 'v1' \n" +
+                        "3. Click 'Test Connection' above\n\n" +
                         "💡 Keyboard shortcut: Ctrl+Shift+L opens chat");
 
         // Try to load models
@@ -107,13 +121,15 @@ public class SetupWizardDialog extends TitleAreaDialog {
 
     private void testConnection() {
         String endpoint = endpointText.getText().trim();
-        EclipseLlamaPreferences.setOllamaEndpoint(endpoint);
+        EclipseLlamaPreferences.setEndpoint(endpoint);
+        String apiKey = apiKeyText.getText().trim();
+        EclipseLlamaPreferences.setApiKey(apiKey);
 
         statusLabel.setText("Testing connection...");
 
         new Thread(() -> {
-            boolean reachable = OllamaClient.isServerReachable();
-            String[] models = reachable ? OllamaClient.getAvailableModels() : new String[0];
+            boolean reachable = ClientProvider.getClient().isServerReachable();
+            String[] models = reachable ? ClientProvider.getClient().getAvailableModels() : new String[0];
 
             Display.getDefault().asyncExec(() -> {
                 if (reachable) {
@@ -137,7 +153,7 @@ public class SetupWizardDialog extends TitleAreaDialog {
                         }
                     }
                 } else {
-                    statusLabel.setText("❌ Cannot connect. Is Ollama running?");
+                    statusLabel.setText("❌ Cannot connect. Is endpoint running?");
                 }
             });
         }).start();
@@ -152,7 +168,8 @@ public class SetupWizardDialog extends TitleAreaDialog {
     @Override
     protected void okPressed() {
         // Save settings
-        EclipseLlamaPreferences.setOllamaEndpoint(endpointText.getText().trim());
+        EclipseLlamaPreferences.setEndpoint(endpointText.getText().trim());
+        EclipseLlamaPreferences.setApiKey(apiKeyText.getText().trim());
 
         String selectedModel = modelCombo.getText();
         if (!selectedModel.isEmpty()) {

--- a/src/com/eclipsellama/plugin/ui/chat/ChatView.java
+++ b/src/com/eclipsellama/plugin/ui/chat/ChatView.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.part.ViewPart;
 
 import com.eclipsellama.plugin.core.ChatMessage;
+import com.eclipsellama.plugin.core.ClientProvider;
 import com.eclipsellama.plugin.core.OllamaClient;
 import com.eclipsellama.plugin.preferences.EclipseLlamaPreferences;
 
@@ -223,10 +224,10 @@ public class ChatView extends ViewPart {
         modelCombo.removeAll();
 
         new Thread(() -> {
-            String[] models = OllamaClient.getAvailableModels();
+            String[] models = ClientProvider.getClient().getAvailableModels();
             Display.getDefault().asyncExec(() -> {
                 if (models.length == 0) {
-                    statusLabel.setText("⚠️ No models found. Is Ollama running?");
+                    statusLabel.setText("⚠️ No models found. Is endpoint running?");
                     for (String model : EclipseLlamaPreferences.getRecommendedCodeModels()) {
                         modelCombo.add(model);
                     }
@@ -274,7 +275,7 @@ public class ChatView extends ViewPart {
         // Create assistant bubble for streaming
         currentAssistantBubble = addMessageBubble("🦙 EclipseLlama", "", false);
 
-        OllamaClient.streamChat(
+        ClientProvider.getClient().streamChat(
                 conversation,
                 model,
                 this::onChunk,


### PR DESCRIPTION
Added an openai compatible client in order to use eclipsellama with open ai endpoints (especially local llama-server endpoints). Tried to keep the two implementations seperate for seperation of concerns. Reused existing endpoint url in config, as open ai urls can be auto-detected by 'v1' in the url.
Tested locally with llama-server serving qwen3.5_30b_a3b (nice coding model).